### PR TITLE
fix: update binary name to match goreleaser configuration

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,20 +8,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    bin: ./epss-plugin
-    uri: ./epss-plugin
+    bin: ./epss
+    uri: ./epss
   - selector:
       os: darwin
       arch: arm64
-    bin: ./epss-plugin
-    uri: ./epss-plugin
+    bin: ./epss
+    uri: ./epss
   - selector:
       os: linux
       arch: amd64
-    bin: ./epss-plugin
-    uri: ./epss-plugin
+    bin: ./epss
+    uri: ./epss
   - selector:
       os: linux
       arch: arm64
-    bin: ./epss-plugin
-    uri: ./epss-plugin
+    bin: ./epss
+    uri: ./epss


### PR DESCRIPTION
# Fix plugin installation for Trivy 0.58+

## Description
This PR fixes the plugin installation issue reported in #1 where the plugin fails to install on Trivy 0.58+ due to a mismatch between the binary name in `plugin.yaml` and the actual binary name produced by goreleaser.

## Changes
- Updated `plugin.yaml` to use the correct binary name `epss` instead of `epss-plugin` to match the goreleaser configuration
- This ensures consistency between the built binary name and the plugin configuration

## Testing
To test this fix:
1. Build and install the plugin locally:
```bash
go build -o epss
trivy plugin install .
```
2. Verify the plugin is installed:
```bash
trivy plugin list
```

## Related Issues
Fixes #1 

## Additional Notes
- The binary name mismatch was causing the plugin installation to fail with the error: `unable to download the execution file (./epss-plugin): failed to download ./epss-plugin: stat /tmp/trivy-downloa