### PR TITLE
fix: update GoReleaser action to v6 and configuration to v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,14 +16,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.22.1
-          args: release -f=goreleaser.yaml --rm-dist --timeout 60m
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update goreleaser/goreleaser-action from v5 to v6
- Update actions/setup-go from v4 to v5
- Configure GoReleaser to use v2 distribution
- Simplify release command arguments

This change addresses the compatibility issue with GoReleaser v2 configuration.

Fix #10 